### PR TITLE
Correct processing of 'relative' object

### DIFF
--- a/custom_components/yandex_smart_home/capability.py
+++ b/custom_components/yandex_smart_home/capability.py
@@ -753,16 +753,17 @@ class VolumeCapability(_RangeCapability):
 
     async def set_state(self, data, state):
         """Set device state."""
-        if self.is_relative_volume_only():
+        if 'relative' in state and state['relative']:
             if state['value'] > 0:
                 service = media_player.SERVICE_VOLUME_UP
             else:
                 service = media_player.SERVICE_VOLUME_DOWN
-            await self.hass.services.async_call(
-                media_player.DOMAIN,
-                service, {
-                    ATTR_ENTITY_ID: self.state.entity_id
-                }, blocking=True, context=data.context)
+            for i in range(abs(state['value'])):
+                await self.hass.services.async_call(
+                    media_player.DOMAIN,
+                    service, {
+                        ATTR_ENTITY_ID: self.state.entity_id
+                    }, blocking=True, context=data.context)
         else:
             await self.hass.services.async_call(
                 media_player.DOMAIN,


### PR DESCRIPTION
Correct processing of the 'relative' object in the request for changing the volume.
1) Даже если наш объект не объявлен, как relative, к нему может приходить запрос с параметром relative:true при управлении голосом, а не из Квазара.
2) Параметр 'value' в данном случае показывает на сколько шагов (задаётся в range.precision) надо увеличить или уменьшить громкость, в зависимости от знака параметра.